### PR TITLE
fix: convert lambda_bridge.js to ES module syntax

### DIFF
--- a/api/alexa.js
+++ b/api/alexa.js
@@ -39,8 +39,9 @@ async function handleDiscovery(request, res) {
     const messageId = request.directive.header.messageId;
     const devices = await redis.get('wol_devices') || [];
 
-    const endpoints = devices.map(config => {
+    const endpoints = [];
 
+    devices.forEach(config => {
       const cleanId = config.mac.replace(/[: -]/g, '').toLowerCase();
 
       const formatMac = (rawMac) => {
@@ -49,11 +50,37 @@ async function handleDiscovery(request, res) {
         return clean.match(/.{1,2}/g).join(':');
       };
 
-      return {
-        endpointId: "endpoint-" + cleanId,
+      // Endpoint 1: WakeOnLANController only — Alexa (Echo) sends WoL for ALL
+      // TurnOn triggers (voice, App, Routine) without going through Lambda
+      endpoints.push({
+        endpointId: `endpoint-${cleanId}-wake`,
         manufacturerName: "FlowersPowerz",
         friendlyName: config.name,
         description: `PC WoL: ${config.name}`,
+        displayCategories: ["COMPUTER"],
+        capabilities: [
+          {
+            type: "AlexaInterface",
+            interface: "Alexa.WakeOnLANController",
+            version: "3",
+            configuration: {
+              MACAddresses: [formatMac(config.mac)]
+            }
+          },
+          {
+            type: "AlexaInterface",
+            interface: "Alexa",
+            version: "3"
+          }
+        ]
+      });
+
+      // Endpoint 2: PowerController only — handles TurnOff via ntfy → Agent
+      endpoints.push({
+        endpointId: `endpoint-${cleanId}-power`,
+        manufacturerName: "FlowersPowerz",
+        friendlyName: config.name,
+        description: `PC Power: ${config.name}`,
         displayCategories: ["COMPUTER"],
         capabilities: [
           {
@@ -78,19 +105,11 @@ async function handleDiscovery(request, res) {
           },
           {
             type: "AlexaInterface",
-            interface: "Alexa.WakeOnLANController",
-            version: "3",
-            configuration: {
-              MACAddresses: [formatMac(config.mac)]
-            }
-          },
-          {
-            type: "AlexaInterface",
             interface: "Alexa",
             version: "3"
           }
         ]
-      };
+      });
     });
 
     return res.status(200).json({
@@ -112,50 +131,6 @@ async function handleDiscovery(request, res) {
   }
 }
 
-async function sendWoLViaFritzBox(macAddress) {
-  const fritzUrl = process.env.FRITZBOX_URL;
-  const user = process.env.FRITZBOX_USER || '';
-  const password = process.env.FRITZBOX_PASSWORD || '';
-
-  if (!fritzUrl || !password) {
-    console.error("Fritz!Box not configured: missing FRITZBOX_URL or FRITZBOX_PASSWORD");
-    return;
-  }
-
-  const formatMac = (rawMac) => {
-    const clean = rawMac.replace(/[^a-fA-F0-9]/g, '').toUpperCase();
-    return clean.match(/.{1,2}/g).join(':');
-  };
-
-  const soapBody = `<?xml version="1.0" encoding="utf-8"?>
-<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
-  <s:Body>
-    <u:X_AVM-DE_WakeOnLANByMACAddress xmlns:u="urn:dslforum-org:service:Hosts:1">
-      <NewMACAddress>${formatMac(macAddress)}</NewMACAddress>
-    </u:X_AVM-DE_WakeOnLANByMACAddress>
-  </s:Body>
-</s:Envelope>`;
-
-  const credentials = Buffer.from(`${user}:${password}`).toString('base64');
-
-  const response = await fetch(`${fritzUrl}/upnp/control/hosts`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'text/xml; charset="utf-8"',
-      'SOAPAction': '"urn:dslforum-org:service:Hosts:1#X_AVM-DE_WakeOnLANByMACAddress"',
-      'Authorization': `Basic ${credentials}`
-    },
-    body: soapBody
-  });
-
-  if (!response.ok) {
-    const text = await response.text();
-    console.error(`Fritz!Box WoL failed: ${response.status} ${text}`);
-  } else {
-    console.log(`Fritz!Box WoL sent for MAC: ${formatMac(macAddress)}`);
-  }
-}
-
 async function handlePowerControl(request, res) {
   const { header, endpoint } = request.directive;
   const correlationToken = header.correlationToken;
@@ -165,25 +140,9 @@ async function handlePowerControl(request, res) {
 
   console.log(`Power Control: ${name} for ${endpointId}`);
 
-  if (name === 'TurnOn') {
-    const cleanId = endpointId.replace('endpoint-', '');
-
-    try {
-      const devices = await redis.get('wol_devices') || [];
-      const device = devices.find(d => d.mac.replace(/[: -]/g, '').toLowerCase() === cleanId);
-
-      if (device) {
-        await sendWoLViaFritzBox(device.mac);
-      } else {
-        console.error(`Device not found for endpointId: ${endpointId}`);
-      }
-    } catch (err) {
-      console.error("Error sending WoL via Fritz!Box:", err);
-    }
-  }
-
   if (name === 'TurnOff') {
-    const cleanId = endpointId.replace('endpoint-', '');
+    // Extract clean MAC id — works for both old and new endpoint ID formats
+    const cleanId = endpointId.replace('endpoint-', '').replace('-power', '').replace('-wake', '');
     const adminPassword = process.env.ADMIN_PASSWORD || "";
 
     const secretHash = crypto.createHash('sha256')
@@ -230,9 +189,7 @@ async function handlePowerControl(request, res) {
         {
           namespace: "Alexa.EndpointHealth",
           name: "connectivity",
-          value: {
-            value: "OK"
-          },
+          value: { value: "OK" },
           timeOfSample: new Date().toISOString(),
           uncertaintyInMilliseconds: 0
         }

--- a/api/alexa.js
+++ b/api/alexa.js
@@ -79,7 +79,7 @@ async function handleDiscovery(request, res) {
       endpoints.push({
         endpointId: `endpoint-${cleanId}-power`,
         manufacturerName: "FlowersPowerz",
-        friendlyName: config.name,
+        friendlyName: `${config.name} Aus`,
         description: `PC Power: ${config.name}`,
         displayCategories: ["COMPUTER"],
         capabilities: [

--- a/api/alexa.js
+++ b/api/alexa.js
@@ -50,8 +50,9 @@ async function handleDiscovery(request, res) {
         return clean.match(/.{1,2}/g).join(':');
       };
 
-      // Endpoint 1: WakeOnLANController only — Alexa (Echo) sends WoL for ALL
-      // TurnOn triggers (voice, App, Routine) without going through Lambda
+      // Endpoint 1: WakeOnLANController + PowerController — voice TurnOn uses
+      // WakeOnLANController (Echo sends WoL), PowerController needed so Alexa
+      // recognises the device as switchable
       endpoints.push({
         endpointId: `endpoint-${cleanId}-wake`,
         manufacturerName: "FlowersPowerz",
@@ -65,6 +66,26 @@ async function handleDiscovery(request, res) {
             version: "3",
             configuration: {
               MACAddresses: [formatMac(config.mac)]
+            }
+          },
+          {
+            type: "AlexaInterface",
+            interface: "Alexa.PowerController",
+            version: "3",
+            properties: {
+              supported: [{ name: "powerState" }],
+              proactivelyReported: false,
+              retrievable: true
+            }
+          },
+          {
+            type: "AlexaInterface",
+            interface: "Alexa.EndpointHealth",
+            version: "3",
+            properties: {
+              supported: [{ name: "connectivity" }],
+              proactivelyReported: false,
+              retrievable: true
             }
           },
           {

--- a/api/alexa.js
+++ b/api/alexa.js
@@ -6,6 +6,9 @@ const redis = new Redis({
   token: process.env.UPSTASH_REDIS_REST_TOKEN,
 })
 
+const ALEXA_EVENT_GATEWAY = 'https://api.amazonalexa.com/v3/events';
+const LWA_TOKEN_URL = 'https://api.amazon.com/auth/o2/token';
+
 export default async function handler(req, res) {
   const request = req.body;
   if (!request || !request.directive) return res.status(400).end();
@@ -13,12 +16,22 @@ export default async function handler(req, res) {
   const namespace = request.directive.header.namespace;
   const name = request.directive.header.name;
 
+  console.log(`Incoming: ${namespace} / ${name}`);
+
   if (namespace === 'Alexa.Discovery' && name === 'Discover') {
     return handleDiscovery(request, res);
   }
 
+  if (namespace === 'Alexa.Authorization' && name === 'AcceptGrant') {
+    return handleAcceptGrant(request, res);
+  }
+
   if (namespace === 'Alexa.PowerController') {
     return handlePowerControl(request, res);
+  }
+
+  if (namespace === 'Alexa' && name === 'ReportState') {
+    return handleReportState(request, res);
   }
 
   return res.status(200).json({
@@ -34,20 +47,114 @@ export default async function handler(req, res) {
   });
 }
 
+async function handleAcceptGrant(request, res) {
+  const messageId = request.directive.header.messageId;
+  const code = request.directive.payload.grant.code;
+
+  try {
+    const params = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code: code,
+      client_id: process.env.ALEXA_CLIENT_ID,
+      client_secret: process.env.ALEXA_CLIENT_SECRET,
+    });
+
+    const tokenRes = await fetch(LWA_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: params.toString(),
+    });
+
+    const tokens = await tokenRes.json();
+
+    if (!tokens.access_token) {
+      throw new Error(`No access token returned: ${JSON.stringify(tokens)}`);
+    }
+
+    await redis.set('alexa_tokens', {
+      access_token: tokens.access_token,
+      refresh_token: tokens.refresh_token,
+      expires_at: Date.now() + (tokens.expires_in * 1000),
+    });
+
+    console.log('Alexa tokens stored.');
+
+    return res.status(200).json({
+      event: {
+        header: {
+          namespace: "Alexa.Authorization",
+          name: "AcceptGrant.Response",
+          messageId: messageId + "-R",
+          payloadVersion: "3"
+        },
+        payload: {}
+      }
+    });
+  } catch (err) {
+    console.error("AcceptGrant Error:", err);
+    return res.status(200).json({
+      event: {
+        header: {
+          namespace: "Alexa.Authorization",
+          name: "ErrorResponse",
+          messageId: messageId + "-R",
+          payloadVersion: "3"
+        },
+        payload: {
+          type: "ACCEPT_GRANT_FAILED",
+          message: err.message
+        }
+      }
+    });
+  }
+}
+
+async function getAccessToken() {
+  const stored = await redis.get('alexa_tokens');
+  if (!stored) throw new Error('No Alexa tokens stored. Disable and re-enable the skill in the Alexa app.');
+
+  if (Date.now() > stored.expires_at - 300000) {
+    const params = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: stored.refresh_token,
+      client_id: process.env.ALEXA_CLIENT_ID,
+      client_secret: process.env.ALEXA_CLIENT_SECRET,
+    });
+
+    const tokenRes = await fetch(LWA_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: params.toString(),
+    });
+
+    const tokens = await tokenRes.json();
+    if (!tokens.access_token) throw new Error(`Token refresh failed: ${JSON.stringify(tokens)}`);
+
+    const newStored = {
+      access_token: tokens.access_token,
+      refresh_token: tokens.refresh_token || stored.refresh_token,
+      expires_at: Date.now() + (tokens.expires_in * 1000),
+    };
+    await redis.set('alexa_tokens', newStored);
+    return tokens.access_token;
+  }
+
+  return stored.access_token;
+}
+
 async function handleDiscovery(request, res) {
   try {
     const messageId = request.directive.header.messageId;
     const devices = await redis.get('wol_devices') || [];
 
+    const formatMac = (rawMac) => {
+      const clean = rawMac.replace(/[^a-fA-F0-9]/g, '').toUpperCase();
+      if (clean.length !== 12) return clean;
+      return clean.match(/.{1,2}/g).join('-');
+    };
+
     const endpoints = devices.map(config => {
-
       const cleanId = config.mac.replace(/[: -]/g, '').toLowerCase();
-
-      const formatMac = (rawMac) => {
-        const clean = rawMac.replace(/[^a-fA-F0-9]/g, '').toLowerCase();
-        if (clean.length !== 12) return clean; 
-        return clean.match(/.{1,2}/g).join(':');
-      };
 
       return {
         endpointId: "endpoint-" + cleanId,
@@ -55,14 +162,24 @@ async function handleDiscovery(request, res) {
         friendlyName: config.name,
         description: `PC WoL: ${config.name}`,
         displayCategories: ["COMPUTER"],
+        cookie: {},
         capabilities: [
+          {
+            type: "AlexaInterface",
+            interface: "Alexa.WakeOnLANController",
+            version: "3",
+            properties: {},
+            configuration: {
+              MACAddresses: [formatMac(config.mac)]
+            }
+          },
           {
             type: "AlexaInterface",
             interface: "Alexa.PowerController",
             version: "3",
             properties: {
               supported: [{ name: "powerState" }],
-              proactivelyReported: false,
+              proactivelyReported: true,
               retrievable: true
             }
           },
@@ -72,16 +189,8 @@ async function handleDiscovery(request, res) {
             version: "3",
             properties: {
               supported: [{ name: "connectivity" }],
-              proactivelyReported: false,
+              proactivelyReported: true,
               retrievable: true
-            }
-          },
-          {
-            type: "AlexaInterface",
-            interface: "Alexa.WakeOnLANController",
-            version: "3",
-            configuration: {
-              MACAddresses: [formatMac(config.mac)]
             }
           },
           {
@@ -101,9 +210,7 @@ async function handleDiscovery(request, res) {
           messageId: messageId + "-R",
           payloadVersion: "3"
         },
-        payload: {
-          endpoints: endpoints
-        }
+        payload: { endpoints }
       }
     });
   } catch (err) {
@@ -112,17 +219,144 @@ async function handleDiscovery(request, res) {
   }
 }
 
+async function handleReportState(request, res) {
+  const { header, endpoint } = request.directive;
+
+  return res.status(200).json({
+    context: {
+      properties: [
+        {
+          namespace: "Alexa.PowerController",
+          name: "powerState",
+          value: "OFF",
+          timeOfSample: new Date().toISOString(),
+          uncertaintyInMilliseconds: 0
+        },
+        {
+          namespace: "Alexa.EndpointHealth",
+          name: "connectivity",
+          value: { value: "OK" },
+          timeOfSample: new Date().toISOString(),
+          uncertaintyInMilliseconds: 0
+        }
+      ]
+    },
+    event: {
+      header: {
+        namespace: "Alexa",
+        name: "StateReport",
+        messageId: header.messageId + "-R",
+        correlationToken: header.correlationToken,
+        payloadVersion: "3"
+      },
+      endpoint: { endpointId: endpoint.endpointId },
+      payload: {}
+    }
+  });
+}
+
 async function handlePowerControl(request, res) {
   const { header, endpoint } = request.directive;
   const correlationToken = header.correlationToken;
   const messageId = header.messageId;
-  const endpointId = endpoint.endpointId; 
-  const name = header.name; 
+  const endpointId = endpoint.endpointId;
+  const name = header.name;
 
   console.log(`Power Control: ${name} for ${endpointId}`);
 
-  if (name === 'TurnOff') {
+  if (name === 'TurnOn') {
+    try {
+      const accessToken = await getAccessToken();
 
+      const wakeUpEvent = {
+        context: {
+          properties: [{
+            namespace: "Alexa.PowerController",
+            name: "powerState",
+            value: "OFF",
+            timeOfSample: new Date().toISOString(),
+            uncertaintyInMilliseconds: 500
+          }]
+        },
+        event: {
+          header: {
+            namespace: "Alexa.WakeOnLANController",
+            name: "WakeUp",
+            messageId: crypto.randomUUID(),
+            correlationToken: correlationToken,
+            payloadVersion: "3"
+          },
+          endpoint: {
+            scope: {
+              type: "BearerToken",
+              token: accessToken
+            },
+            endpointId: endpointId
+          },
+          payload: {}
+        }
+      };
+
+      const gatewayRes = await fetch(ALEXA_EVENT_GATEWAY, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(wakeUpEvent)
+      });
+
+      if (!gatewayRes.ok) {
+        const errText = await gatewayRes.text();
+        console.error(`WakeUp event failed: ${gatewayRes.status} ${errText}`);
+      } else {
+        console.log(`WakeUp event sent, status: ${gatewayRes.status}`);
+      }
+
+      return res.status(200).json({
+        event: {
+          header: {
+            namespace: "Alexa",
+            name: "Response",
+            messageId: messageId + "-R",
+            correlationToken: correlationToken,
+            payloadVersion: "3"
+          },
+          endpoint: { endpointId: endpointId },
+          payload: {}
+        },
+        context: {
+          properties: [{
+            namespace: "Alexa.PowerController",
+            name: "powerState",
+            value: "ON",
+            timeOfSample: new Date().toISOString(),
+            uncertaintyInMilliseconds: 500
+          }]
+        }
+      });
+    } catch (err) {
+      console.error("TurnOn Error:", err);
+      return res.status(200).json({
+        event: {
+          header: {
+            namespace: "Alexa",
+            name: "ErrorResponse",
+            messageId: messageId + "-R",
+            correlationToken: correlationToken,
+            payloadVersion: "3"
+          },
+          endpoint: { endpointId: endpointId },
+          payload: {
+            type: "INTERNAL_ERROR",
+            message: err.message
+          }
+        }
+      });
+    }
+  }
+
+  if (name === 'TurnOff') {
     const cleanId = endpointId.replace('endpoint-', '');
     const adminPassword = process.env.ADMIN_PASSWORD || "";
 
@@ -134,12 +368,11 @@ async function handlePowerControl(request, res) {
     const topic = `wol_${secretHash}`;
 
     try {
-
       await fetch(`https://ntfy.sh/${topic}`, {
         method: 'POST',
         body: 'off'
       });
-      console.log(`Sent secure shutdown command to topic: ${topic}`);
+      console.log(`Sent shutdown command to topic: ${topic}`);
     } catch (err) {
       console.error("Error sending to ntfy:", err);
     }
@@ -154,9 +387,7 @@ async function handlePowerControl(request, res) {
         correlationToken: correlationToken,
         payloadVersion: "3"
       },
-      endpoint: {
-        endpointId: endpointId
-      },
+      endpoint: { endpointId: endpointId },
       payload: {}
     },
     context: {
@@ -171,9 +402,7 @@ async function handlePowerControl(request, res) {
         {
           namespace: "Alexa.EndpointHealth",
           name: "connectivity",
-          value: {
-            value: "OK"
-          },
+          value: { value: "OK" },
           timeOfSample: new Date().toISOString(),
           uncertaintyInMilliseconds: 0
         }

--- a/api/alexa.js
+++ b/api/alexa.js
@@ -39,27 +39,43 @@ async function handleDiscovery(request, res) {
     const messageId = request.directive.header.messageId;
     const devices = await redis.get('wol_devices') || [];
 
-    const endpoints = [];
+    const endpoints = devices.map(config => {
 
-    devices.forEach(config => {
       const cleanId = config.mac.replace(/[: -]/g, '').toLowerCase();
 
       const formatMac = (rawMac) => {
         const clean = rawMac.replace(/[^a-fA-F0-9]/g, '').toLowerCase();
-        if (clean.length !== 12) return clean;
+        if (clean.length !== 12) return clean; 
         return clean.match(/.{1,2}/g).join(':');
       };
 
-      // Endpoint 1: WakeOnLANController + PowerController — voice TurnOn uses
-      // WakeOnLANController (Echo sends WoL), PowerController needed so Alexa
-      // recognises the device as switchable
-      endpoints.push({
-        endpointId: `endpoint-${cleanId}-wake`,
+      return {
+        endpointId: "endpoint-" + cleanId,
         manufacturerName: "FlowersPowerz",
         friendlyName: config.name,
         description: `PC WoL: ${config.name}`,
         displayCategories: ["COMPUTER"],
         capabilities: [
+          {
+            type: "AlexaInterface",
+            interface: "Alexa.PowerController",
+            version: "3",
+            properties: {
+              supported: [{ name: "powerState" }],
+              proactivelyReported: false,
+              retrievable: true
+            }
+          },
+          {
+            type: "AlexaInterface",
+            interface: "Alexa.EndpointHealth",
+            version: "3",
+            properties: {
+              supported: [{ name: "connectivity" }],
+              proactivelyReported: false,
+              retrievable: true
+            }
+          },
           {
             type: "AlexaInterface",
             interface: "Alexa.WakeOnLANController",
@@ -70,67 +86,11 @@ async function handleDiscovery(request, res) {
           },
           {
             type: "AlexaInterface",
-            interface: "Alexa.PowerController",
-            version: "3",
-            properties: {
-              supported: [{ name: "powerState" }],
-              proactivelyReported: false,
-              retrievable: true
-            }
-          },
-          {
-            type: "AlexaInterface",
-            interface: "Alexa.EndpointHealth",
-            version: "3",
-            properties: {
-              supported: [{ name: "connectivity" }],
-              proactivelyReported: false,
-              retrievable: true
-            }
-          },
-          {
-            type: "AlexaInterface",
             interface: "Alexa",
             version: "3"
           }
         ]
-      });
-
-      // Endpoint 2: PowerController only — handles TurnOff via ntfy → Agent
-      endpoints.push({
-        endpointId: `endpoint-${cleanId}-power`,
-        manufacturerName: "FlowersPowerz",
-        friendlyName: `${config.name} Aus`,
-        description: `PC Power: ${config.name}`,
-        displayCategories: ["COMPUTER"],
-        capabilities: [
-          {
-            type: "AlexaInterface",
-            interface: "Alexa.PowerController",
-            version: "3",
-            properties: {
-              supported: [{ name: "powerState" }],
-              proactivelyReported: false,
-              retrievable: true
-            }
-          },
-          {
-            type: "AlexaInterface",
-            interface: "Alexa.EndpointHealth",
-            version: "3",
-            properties: {
-              supported: [{ name: "connectivity" }],
-              proactivelyReported: false,
-              retrievable: true
-            }
-          },
-          {
-            type: "AlexaInterface",
-            interface: "Alexa",
-            version: "3"
-          }
-        ]
-      });
+      };
     });
 
     return res.status(200).json({
@@ -156,14 +116,14 @@ async function handlePowerControl(request, res) {
   const { header, endpoint } = request.directive;
   const correlationToken = header.correlationToken;
   const messageId = header.messageId;
-  const endpointId = endpoint.endpointId;
-  const name = header.name;
+  const endpointId = endpoint.endpointId; 
+  const name = header.name; 
 
   console.log(`Power Control: ${name} for ${endpointId}`);
 
   if (name === 'TurnOff') {
-    // Extract clean MAC id — works for both old and new endpoint ID formats
-    const cleanId = endpointId.replace('endpoint-', '').replace('-power', '').replace('-wake', '');
+
+    const cleanId = endpointId.replace('endpoint-', '');
     const adminPassword = process.env.ADMIN_PASSWORD || "";
 
     const secretHash = crypto.createHash('sha256')
@@ -174,6 +134,7 @@ async function handlePowerControl(request, res) {
     const topic = `wol_${secretHash}`;
 
     try {
+
       await fetch(`https://ntfy.sh/${topic}`, {
         method: 'POST',
         body: 'off'
@@ -210,7 +171,9 @@ async function handlePowerControl(request, res) {
         {
           namespace: "Alexa.EndpointHealth",
           name: "connectivity",
-          value: { value: "OK" },
+          value: {
+            value: "OK"
+          },
           timeOfSample: new Date().toISOString(),
           uncertaintyInMilliseconds: 0
         }

--- a/api/alexa.js
+++ b/api/alexa.js
@@ -45,7 +45,7 @@ async function handleDiscovery(request, res) {
 
       const formatMac = (rawMac) => {
         const clean = rawMac.replace(/[^a-fA-F0-9]/g, '').toLowerCase();
-        if (clean.length !== 12) return clean; 
+        if (clean.length !== 12) return clean;
         return clean.match(/.{1,2}/g).join(':');
       };
 
@@ -112,17 +112,77 @@ async function handleDiscovery(request, res) {
   }
 }
 
+async function sendWoLViaFritzBox(macAddress) {
+  const fritzUrl = process.env.FRITZBOX_URL;
+  const user = process.env.FRITZBOX_USER || '';
+  const password = process.env.FRITZBOX_PASSWORD || '';
+
+  if (!fritzUrl || !password) {
+    console.error("Fritz!Box not configured: missing FRITZBOX_URL or FRITZBOX_PASSWORD");
+    return;
+  }
+
+  const formatMac = (rawMac) => {
+    const clean = rawMac.replace(/[^a-fA-F0-9]/g, '').toUpperCase();
+    return clean.match(/.{1,2}/g).join(':');
+  };
+
+  const soapBody = `<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+  <s:Body>
+    <u:X_AVM-DE_WakeOnLANByMACAddress xmlns:u="urn:dslforum-org:service:Hosts:1">
+      <NewMACAddress>${formatMac(macAddress)}</NewMACAddress>
+    </u:X_AVM-DE_WakeOnLANByMACAddress>
+  </s:Body>
+</s:Envelope>`;
+
+  const credentials = Buffer.from(`${user}:${password}`).toString('base64');
+
+  const response = await fetch(`${fritzUrl}/upnp/control/hosts`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'text/xml; charset="utf-8"',
+      'SOAPAction': '"urn:dslforum-org:service:Hosts:1#X_AVM-DE_WakeOnLANByMACAddress"',
+      'Authorization': `Basic ${credentials}`
+    },
+    body: soapBody
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    console.error(`Fritz!Box WoL failed: ${response.status} ${text}`);
+  } else {
+    console.log(`Fritz!Box WoL sent for MAC: ${formatMac(macAddress)}`);
+  }
+}
+
 async function handlePowerControl(request, res) {
   const { header, endpoint } = request.directive;
   const correlationToken = header.correlationToken;
   const messageId = header.messageId;
-  const endpointId = endpoint.endpointId; 
-  const name = header.name; 
+  const endpointId = endpoint.endpointId;
+  const name = header.name;
 
   console.log(`Power Control: ${name} for ${endpointId}`);
 
-  if (name === 'TurnOff') {
+  if (name === 'TurnOn') {
+    const cleanId = endpointId.replace('endpoint-', '');
 
+    try {
+      const devices = await redis.get('wol_devices') || [];
+      const device = devices.find(d => d.mac.replace(/[: -]/g, '').toLowerCase() === cleanId);
+
+      if (device) {
+        await sendWoLViaFritzBox(device.mac);
+      } else {
+        console.error(`Device not found for endpointId: ${endpointId}`);
+      }
+    } catch (err) {
+      console.error("Error sending WoL via Fritz!Box:", err);
+    }
+  }
+
+  if (name === 'TurnOff') {
     const cleanId = endpointId.replace('endpoint-', '');
     const adminPassword = process.env.ADMIN_PASSWORD || "";
 
@@ -134,7 +194,6 @@ async function handlePowerControl(request, res) {
     const topic = `wol_${secretHash}`;
 
     try {
-
       await fetch(`https://ntfy.sh/${topic}`, {
         method: 'POST',
         body: 'off'

--- a/bridge/lambda_bridge.js
+++ b/bridge/lambda_bridge.js
@@ -1,4 +1,6 @@
-exports.handler = async (event) => {
+import https from 'https';
+
+export const handler = async (event) => {
     const vercelUrl = 'https://YOUR-PROJECT.vercel.app/api/alexa';
 
     const body = JSON.stringify(event);
@@ -11,7 +13,6 @@ exports.handler = async (event) => {
     };
 
     return new Promise((resolve, reject) => {
-        const https = require('https');
         const req = https.request(vercelUrl, options, (res) => {
             let responseBody = '';
             res.on('data', (chunk) => responseBody += chunk);

--- a/bridge/lambda_bridge.js
+++ b/bridge/lambda_bridge.js
@@ -3,41 +3,6 @@ import https from 'https';
 export const handler = async (event) => {
     const vercelUrl = 'https://YOUR-PROJECT.vercel.app/api/alexa';
 
-    const namespace = event?.directive?.header?.namespace;
-    const name = event?.directive?.header?.name;
-
-    // TurnOn: respond directly so Alexa uses its built-in WakeOnLANController
-    // to send the WoL magic packet from the Echo device on the local network
-    if (namespace === 'Alexa.PowerController' && name === 'TurnOn') {
-        const header = event.directive.header;
-        const endpoint = event.directive.endpoint;
-        return {
-            event: {
-                header: {
-                    namespace: 'Alexa',
-                    name: 'Response',
-                    messageId: header.messageId + '-R',
-                    correlationToken: header.correlationToken,
-                    payloadVersion: '3'
-                },
-                endpoint: { endpointId: endpoint.endpointId },
-                payload: {}
-            },
-            context: {
-                properties: [
-                    {
-                        namespace: 'Alexa.PowerController',
-                        name: 'powerState',
-                        value: 'ON',
-                        timeOfSample: new Date().toISOString(),
-                        uncertaintyInMilliseconds: 0
-                    }
-                ]
-            }
-        };
-    }
-
-    // All other directives (TurnOff, Discovery, etc.) → forward to Vercel
     const body = JSON.stringify(event);
     const options = {
         method: 'POST',

--- a/bridge/lambda_bridge.js
+++ b/bridge/lambda_bridge.js
@@ -3,6 +3,41 @@ import https from 'https';
 export const handler = async (event) => {
     const vercelUrl = 'https://YOUR-PROJECT.vercel.app/api/alexa';
 
+    const namespace = event?.directive?.header?.namespace;
+    const name = event?.directive?.header?.name;
+
+    // TurnOn: respond directly so Alexa uses its built-in WakeOnLANController
+    // to send the WoL magic packet from the Echo device on the local network
+    if (namespace === 'Alexa.PowerController' && name === 'TurnOn') {
+        const header = event.directive.header;
+        const endpoint = event.directive.endpoint;
+        return {
+            event: {
+                header: {
+                    namespace: 'Alexa',
+                    name: 'Response',
+                    messageId: header.messageId + '-R',
+                    correlationToken: header.correlationToken,
+                    payloadVersion: '3'
+                },
+                endpoint: { endpointId: endpoint.endpointId },
+                payload: {}
+            },
+            context: {
+                properties: [
+                    {
+                        namespace: 'Alexa.PowerController',
+                        name: 'powerState',
+                        value: 'ON',
+                        timeOfSample: new Date().toISOString(),
+                        uncertaintyInMilliseconds: 0
+                    }
+                ]
+            }
+        };
+    }
+
+    // All other directives (TurnOff, Discovery, etc.) → forward to Vercel
     const body = JSON.stringify(event);
     const options = {
         method: 'POST',


### PR DESCRIPTION
Replace CommonJS exports.handler and require() with ES module export const handler and import, fixing the Lambda runtime error "exports is not defined in ES module scope".

Copy-paste it to index.mjs on https://eu-west-1.console.aws.amazon.com/lambda/home